### PR TITLE
setting up better test rig for io

### DIFF
--- a/cifplotting/io.py
+++ b/cifplotting/io.py
@@ -1,5 +1,8 @@
 import numpy as np
 
+from diffpy.structure.parsers.p_cif import P_cif, _fixIfWindowsPath
+import CifFile
+
 def cif_read(cif_file_path):
     '''
     given a cif file-path, reads the cif and returns the cif data
@@ -11,39 +14,10 @@ def cif_read(cif_file_path):
 
     Returns
     -------
-    the cif data as a dictionary
+    the cif data as a CifFile object
     '''
-    with open(cif_file_path, 'r') as input_file:
-        lines = input_file.readlines()
-    for i in range(0, len(lines)):
-        if '_diffrn_radiation_probe' in lines[i]:
-            probe = lines[i].split()[-1]
-        elif '_diffrn_radiation_wavelength' in lines[i]:
-            wavelength = float(lines[i].split()[-1])
-        elif '_pd_proc_intensity_bkg_calc' in lines[i]:
-            start = i + 2
-        elif '_pd_proc_number_of_points' in lines[i]:
-            end = i
-    tt, int_exp, q = [], [], []
-    for i in range(start, end):
-        tt.append(float(lines[i].split()[1]))
-        q.append(4 * np.pi * np.sin((np.pi / 180) * float(lines[i].split()[1]) / 2) / wavelength)
-        int_exp.append(float(lines[i].split()[2].split('(')[0]))
-    q_min_round_up = np.ceil(min(q) * 10**2) / 10**2
-    q_max_round_down = np.floor(max(q) * 10**2) / 10**2
-    int_scaled = []
-    # int_max = max(int_exp)
-    # for i in range(0, len(int_exp)):
-    #     int_scaled.append(int_exp[i] / int_max)
-    # plt.plot(q, int_scaled)
-    # plt.xlabel(r"$Q$ $[\mathrm{\AA^{-1}}]$")
-    # plt.ylabel(r"$I$ $[\mathrm{a.u.}]$")
-    # plt.show()
-    # sys.exit()
-    cif_data = [tt, q, int_exp, int_scaled, [q_min_round_up, q_max_round_down], probe]
-
-    return cif_data
-    # End of function.
+    cf = CifFile.ReadCif(_fixIfWindowsPath(str(cif_file_path)))
+    return cf
 
 
 def powdercif_pattern_write(cif_file_path, txt_path, data):

--- a/cifplotting/main.py
+++ b/cifplotting/main.py
@@ -3,23 +3,27 @@ from cifplotting.io import cif_read, rank_write, user_input_read
 from cifplotting.plotters import rank_plot
 from cifplotting.utils import data_sample, pearson_correlate
 
+WAVELENGTH = 1.548
+parent_path = Path.cwd().resolve().parent
+data_path = parent_path / 'data'
+cif_dir = data_path / 'cif'
+output_path = parent_path / '_output'
+powder_data_dir = data_path / 'powder_data'
+user_input_file = powder_data_dir / 'sandys_data.txt'
+png_path = output_path / 'png'
+txt_path = output_path / 'txt'
+
+
 def main():
-    WAVELENGTH = 1.548
-    parent_path = Path.cwd().resolve().parent
-    cif_data_path = parent_path / 'data'
-    cif_dir = cif_data_path / 'cif'
-    output_path = parent_path / '_output'
-    powder_data_dir = cif_data_path / 'powder_data'
     cif_file_list = cif_dir.glob("*.cif")
-    user_input_file = powder_data_dir / 'sandys_data.txt'
-    png_path = output_path / 'png'
-    txt_path = output_path / 'txt'
     folders = [output_path, txt_path, png_path]
     for folder in folders:
         if not folder.exists():
             folder.mkdir()
-    print('-'*80 + '\nInput data file: ' + str(user_input_file.name))
-    print('Wavelength: ' + str(WAVELENGTH) + ' Å.')
+    #print('-'*80 + '\nInput data file: ' + str(user_input_file.name))
+    print('-' * 80)
+    print(f"Input data file: {str(user_input_file.name)}")
+    print(f"Wavelength: ' {str(WAVELENGTH)} Å.")
     user_data = user_input_read(user_input_file, WAVELENGTH)
     # int_scaled_user = user_data[2]
     new_user_grid = data_sample(user_data)

--- a/tests/inputs/test_cif_contents.py
+++ b/tests/inputs/test_cif_contents.py
@@ -1,4 +1,0 @@
-cif_contents_string = "\
-_diffrn_radiation_probe                neutrons\n\
-_diffrn_radiation_wavelength            1.5482\n\
-    "

--- a/tests/inputs/test_cifs.py
+++ b/tests/inputs/test_cifs.py
@@ -1,0 +1,40 @@
+# Put cif file patterns here to test cif readers and cif parsers
+#
+# the pattern is as follows
+# testciffiles_contents_expecteds = [(file_1_contents_as_string, file1_expected_as_dict),
+#                          (file_2_contents_as_string, file1_expected_as_dict),
+#                          ...
+#                         ]
+#
+# where the expected outputs has one block with a blockname, a list of block
+#    items and a list of loop items.  Block items are for simple cif_key, cif_value
+#    pairs and loop items are themselves a dict containing lists of keys and values
+
+testciffiles_contents_expecteds = [
+("\
+data_cubic_1_ND\n\
+\n\
+_diffrn_radiation_probe                neutrons\n\
+_diffrn_radiation_wavelength            1.5482\n\
+\n\
+loop_\n\
+_pd_proc_intensity_bkg_calc\n\
+ \n\
+   177    10.0413    2037(166)          1886.0148         1886.0148\n\
+   178    10.0913    2212(172)          1886.0148         1886.0148\n\
+   179    10.1413    2155(169)          1886.0148         1886.0148\n\
+"
+,
+{'block_name': 'cubic_1_ND',
+    "block_items": [("_diffrn_radiation_probe", "neutrons"),
+                    ('_diffrn_radiation_wavelength', '1.5482')
+                    ],
+    "loop_items": [{"keys": ["_pd_proc_intensity_bkg_calc"],
+                  "values": [["177", "10.0413","2037(166)","1886.0148","1886.0148",
+                              "178","10.0913","2212(172)","1886.0148","1886.0148",
+                              "179","10.1413","2155(169)","1886.0148","1886.0148"
+                              ]]
+                  }
+                         ]}
+ )
+]

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,18 +1,28 @@
 from pathlib import Path
+
+import CifFile
+import pytest
 from testfixtures import TempDirectory
 
 from cifplotting.io import cif_read
-from tests.inputs.test_cif_contents import cif_contents_string
+from tests.inputs.test_cifs import testciffiles_contents_expecteds
 
-
-def test_cif_read():
-    cif_bitstream = bytearray(cif_contents_string, 'utf8')
+@pytest.mark.parametrize("cm", testciffiles_contents_expecteds)
+def test_cif_read(cm):
     with TempDirectory() as d:
-        d.write('test_cif.cif',
-                cif_bitstream)
         temp_dir = Path(d.path)
-        test_cif_path = temp_dir / 'test_cif.cif'
+        cif_bitstream = bytearray(cm[0], 'utf8')
+        d.write(f"test_cif.cif",
+                cif_bitstream)
+        test_cif_path = temp_dir / f"test_cif.cif"
         actual = cif_read(test_cif_path)
-    expected = {"_diffrn_radiation_wavelength": 1.5482, 
-                "_diffrn_radiation_probe": "neutrons"}
-    assert actual == expected
+    expected = CifFile.CifFile()
+    expected[cm[1].get('block_name')] = CifFile.CifBlock()
+    cb = expected[cm[1].get('block_name')]
+    for item in cm[1].get('block_items'):
+        cb[item[0]] = item[1]
+    for item in cm[1].get('loop_items'):
+        cb.AddCifItem(([item['keys']],[item['values']]))
+    assert actual.keys() == expected.keys()
+    assert actual[cm[1].get('block_name')].items() == expected[cm[1].get('block_name')].items()
+


### PR DESCRIPTION
@berrakozer @maak-sdu this is a much better setup for testing the io.  I put some notes in the code, but it is using `pycifrw` and is handing back a CifFile() object with all the read blocks from the cif file.  I set up the testing so that it can read a trial cif file that contains a block, some items and a loop and it is passing tests.